### PR TITLE
Broken gimp 2.8.4 source 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class gimp {
   package { 'GNU Image Manipulation Program':
     provider => 'appdmg',
-    source   => 'ftp://ftp.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.4-nopython-dmg-1.dmg',
+    source   => 'http://download.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.4-nopython-dmg-1.dmg',
   }
 }

--- a/spec/classes/gimp_spec.rb
+++ b/spec/classes/gimp_spec.rb
@@ -4,7 +4,7 @@ describe 'gimp' do
   it do
     should contain_package('GNU Image Manipulation Program').with({
       :provider => 'appdmg',
-      :source   => 'ftp://ftp.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.4-nopython-dmg-1.dmg',
+      :source   => 'http://download.gimp.org/pub/gimp/v2.8/osx/gimp-2.8.4-nopython-dmg-1.dmg',
     })
   end
 end


### PR DESCRIPTION
I updated the package's source to be a location where the file can be found.
